### PR TITLE
Revert: e1ddda1, 17b6147, da58b7d

### DIFF
--- a/backend/controllers/note.controller.js
+++ b/backend/controllers/note.controller.js
@@ -1,287 +1,399 @@
 const Note = require("../models/note.model");
-const { findUserNote, findAndUpdateNote, getNoteByIdWithUser } = require("../helpers/noteHelpers");
 const Label = require("../models/label.model");
+const User = require("../models/user.model");
 const logger = require("../logger");
+const { createNotification } = require("./notification.controller");
+const { getNoteByIdWithUser } = require("../helpers/noteHelpers");
 const { errors, success } = require("../config/messages");
+const {
+  ValidationError,
+  NotFoundError
+} = require("../errors");
 
 exports.addNote = async (req, res, next) => {
-  const { title, content, tags = [], isPinned } = req.body;
+  const { title, content, labels = [], isPinned, color } = req.body;
   const user = req.user;
 
-  if (!title || !content) {
-    return res.status(400).json({ error: true, message: errors.titleContentRequired });
-  }
-
   try {
-    const labelDocs = await Label.find({ name: { $in: tags }, userId: user._id }, "_id");
-    const tagIds = labelDocs.map(l => l._id);
+    let labelIds = [];
+    if (labels.length > 0) {
+      const foundLabels = await Label.find({
+        name: { $in: labels },
+        userId: user._id
+      });
 
-    const note = await Note.create({
+      if (foundLabels.length !== labels.length) {
+        throw new ValidationError("One or more labels are invalid.");
+      };
+
+      labelIds = foundLabels.map(label => label._id);
+    };
+
+    const note = new Note({
       title,
       content,
-      tags: tagIds,
-      isPinned: !!isPinned,
+      labels: labelIds,
+      isPinned: isPinned || false,
+      color,
       userId: user._id,
     });
 
+    await note.save();
     const populatedNote = await getNoteByIdWithUser(note._id);
+
     logger.info(`Note added by user: ${user.email}`);
-    return res.json({ error: false, note: populatedNote, message: success.noteAdded });
+    res.status(201).json({
+      success: true,
+      data: populatedNote,
+      message: "Note added successfully"
+    });
   } catch (error) {
     logger.error(`Error adding note: ${error.message}`);
     next(error);
-  }
+  };
 };
 
-exports.editNote = async (req, res) => {
-  const noteId = req.params.noteId;
-  const { title, content, tags, reminder, isPinned } = req.body;
-  const user = req.user;
+exports.editNote = async (req, res, next) => {
+    const noteId = req.params.noteId;
+    const { title, content, labels, reminder, isPinned, color } = req.body;
+    const user = req.user;
 
-  if (!title && !content && !tags && typeof isPinned === "undefined" && !reminder) {
-    return res.status(400).json({ error: true, message: "No changes provided" });
-  }
+    try {
+        const note = await Note.findOne({
+            _id: noteId,
+            $or: [
+                { userId: user._id },
+                { sharedWith: user.email }
+            ],
+        });
+
+        if (!note) {
+            throw new NotFoundError("Note not found or you don't have permission to edit it.");
+        };
+
+        const isOwner = note.userId.toString() === user._id.toString();
+
+        if (title) {
+            note.title = title;
+        };
+
+        if (content) {
+            note.content = content;
+        };
+
+        if (color) {
+            note.color = color;
+        };
+
+        if (Array.isArray(labels)) {
+            if (labels.length > 0) {
+                const foundLabels = await Label.find({
+                    name: { $in: labels },
+                     userId: note.userId 
+                });
+
+                if (foundLabels.length !== labels.length) {
+                    throw new ValidationError("One or more labels are invalid.");
+                };
+
+                note.labels = foundLabels.map(label => label._id);
+            } else {
+                note.labels = [];
+            };
+        };
+
+        if (isOwner) {
+            if (reminder !== undefined) {
+                note.reminder = reminder;
+            };
+
+            if (typeof isPinned !== "undefined") {
+                note.isPinned = isPinned;
+            }
+        };
+
+        await note.save();
+        const populatedNote = await getNoteByIdWithUser(note._id);
+        res.json({
+            success: true,
+            data: populatedNote,
+            message: "Note updated successfully"
+        });
+    } catch (error) {
+        next(error);
+    };
+};
+
+exports.getAllNotes = async (req, res, next) => {
+  const user = req.user;
+  const { searchQuery, labels, sortBy, page = 1, limit = 10 } = req.query;
 
   try {
-    const note = await Note.findOne({ _id: noteId, userId: user._id });
-    if (!note) {
-      return res.status(404).json({ error: true, message: errors.noteNotFound });
-    }
+    const pageLimit = Math.min(parseInt(limit), 50);
+    const skip = (page - 1) * pageLimit;
 
-    if (title) note.title = title;
-    if (content) note.content = content;
-    if (Array.isArray(tags)) {
-      const labelDocs = await Label.find({ name: { $in: tags }, userId: user._id }, "_id");
-      note.tags = labelDocs.map(l => l._id);
+    const filter = {
+      $and: [
+        {
+          $or: [
+            { userId: user._id },
+            { sharedWith: user.email }
+          ]
+        }
+      ]
     };
 
-    if (reminder) note.reminder = reminder;
-    if (typeof isPinned !== "undefined") note.isPinned = isPinned;
-
-    await note.save();
-    const populatedNote = await getNoteByIdWithUser(note._id);
-    return res.json({ error: false, note: populatedNote, message: success.noteUpdated });
-  } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
-  }
-};
-
-exports.getAllNotes = async (req, res) => {
-  const user = req.user;
-  const { searchQuery, tags, sortBy, page = 1, limit = 10 } = req.query;
-
-  if (!user || !user._id) {
-    return res.status(400).json({ error: true, message: errors.authRequired });
-  }
-
-  try {
-    const baseAccess = { $or: [{ userId: user._id }, { sharedWith: user.email }] };
-    const conditions = [baseAccess];
-
     if (searchQuery) {
-      conditions.push({
+      filter.$and.push({
         $or: [
           { title: { $regex: searchQuery, $options: "i" } },
-          { content: { $regex: searchQuery, $options: "i" } },
-        ],
+          { content: { $regex: searchQuery, $options: "i" } }
+        ]
       });
     };
 
-    if (tags && tags !== "") {
-      const tagNames = tags.split(",").map(t => t.trim());
-      const labelDocs = await Label.find({ name: { $in: tagNames }, userId: user._id }, "_id");
-      const labelIds = labelDocs.map(l => l._id);
-      if (labelIds.length) conditions.push({ tags: { $in: labelIds } });
-    }
+    if (labels && labels !== "") {
+      const labelsArray = labels.split(",").map(label => label.trim());
+      const labelDocs = await Label.find({
+        name: { $in: labelsArray },
+        userId: user._id
+      }, "_id");
+      const labelIds = labelDocs.map(label => label._id);
+      filter.$and.push({ labels: { $in: labelIds } });
+    };
 
-    const filter = conditions.length > 1 ? { $and: conditions } : baseAccess;
-
-    let sortOptions = { isPinned: -1, createdOn: -1 };
-    if (sortBy === "created") sortOptions = { createdOn: -1 };
-    else if (sortBy === "updated") sortOptions = { updatedOn: -1 };
-
-    const pageNum = Number(page) || 1;
-    const pageSize = Number(limit) || 10;
+    const sortOptions = { isPinned: -1 };
+    if (sortBy === "created") {
+      sortOptions.createdAt = -1;
+    } else {
+      sortOptions.updatedAt = -1;
+    };
 
     const totalCount = await Note.countDocuments(filter);
     const notes = await Note.find(filter)
+      .populate("labels", "name")
       .populate("userId", "firstName lastName email")
-      .populate("tags", "name")
       .sort(sortOptions)
-      .skip((pageNum - 1) * pageSize)
-      .limit(pageSize)
-      .lean();
+      .skip(skip)
+      .limit(pageLimit);
 
-    return res.json({
-      error: false,
+    res.json({
+      success: true,
       notes,
-      currentPage: pageNum,
-      totalPages: Math.ceil(totalCount / pageSize),
+      currentPage: Number(page),
+      totalPages: Math.ceil(totalCount / pageLimit),
       totalCount,
-      message: success.notesFetched,
+      message: success.notesFetched
     });
   } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
+    next(error);
   };
 };
 
-exports.deleteNote = async (req, res) => {
+exports.deleteNote = async (req, res, next) => {
   const noteId = req.params.noteId;
   const user = req.user;
 
   try {
-    const note = await findUserNote(noteId, user._id);
-    if (!note) {
-      return res.status(404).json({ error: true, message: errors.noteNotFound });
+    const result = await Note.deleteOne({ _id: noteId, userId: user._id });
+    if (result.deletedCount === 0) {
+      throw new NotFoundError(errors.noteNotFound);
     };
 
-    await Note.deleteOne({ _id: noteId, userId: user._id });
-    return res.json({ error: false, message: success.noteDeleted });
+    res.json({ success: true, message: success.noteDeleted });
   } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
+    next(error);
   };
 };
 
-exports.updateNotePinned = async (req, res) => {
-  const noteId = req.params.noteId;
+exports.updateNotePinned = async (req, res, next) => {
+  const { noteId } = req.params;
   const { isPinned } = req.body;
-  const user = req.user;
 
   try {
-    await findAndUpdateNote(noteId, user._id, { isPinned });
-    return res.json({ error: false, message: success.noteUpdated });
+    const note = await Note.findOneAndUpdate(
+      { _id: noteId, userId: req.user._id },
+      { isPinned },
+      { new: true }
+    );
+
+    if (!note) {
+      throw new NotFoundError("Note", noteId);
+    };
+    res.json({ success: true, message: success.noteUpdated, data: note });
   } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
+    next(error);
   };
 };
 
-exports.archiveNote = async (req, res) => {
-  const noteId = req.params.noteId;
+exports.archiveNote = async (req, res, next) => {
+  const { noteId } = req.params;
   const { isArchived } = req.body;
-  const user = req.user;
 
   try {
-    await findAndUpdateNote(noteId, user._id, { isArchived });
-    const msg = isArchived ? success.archived : success.unarchived;
-    return res.json({ error: false, message: msg });
+    const note = await Note.findOneAndUpdate(
+      { _id: noteId, userId: req.user._id },
+      { isArchived }
+    );
+
+    if (!note) {
+      throw new NotFoundError("Note", noteId);
+    };
+
+    const message = isArchived ? success.archived : success.unarchive;
+    res.json({ success: true, message });
   } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
+    next(error);
   };
 };
 
-exports.completeNote = async (req, res) => {
-  const noteId = req.params.noteId;
+exports.completeNote = async (req, res, next) => {
+  const { noteId } = req.params;
   const { isCompleted } = req.body;
-  const user = req.user;
 
   try {
-    await findAndUpdateNote(noteId, user._id, { isCompleted });
-    const msg = isCompleted ? success.completed : success.uncompleted;
-    return res.json({ error: false, message: msg });
+    const note = await Note.findOneAndUpdate(
+      { _id: noteId, userId: req.user._id },
+      { isCompleted }
+    );
+
+    if (!note) {
+      throw new NotFoundError("Note", noteId);
+    };
+
+    const message = isCompleted ? success.completed : success.uncompleted;
+    res.json({ success: true, message });
   } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
+    next(error);
   };
 };
 
-exports.addLabel = async (req, res) => {
+exports.addLabel = async (req, res, next) => {
   const noteId = req.params.noteId;
   const { label } = req.body;
   const user = req.user;
 
-  if (!label || label.trim() === "") {
-    return res.status(400).json({ error: true, message: errors.labelRequired });
-  };
-
   try {
+    const note = await Note.findOne({
+      _id: noteId,
+      $or: [{ userId: user._id }, { sharedWith: user.email }]
+    });
+
+    if (!note) {
+      throw new NotFoundError("Note not found or you don't have permission to edit it.");
+    };
+
     const labelDoc = await Label.findOne({ name: label, userId: user._id });
     if (!labelDoc) {
-      return res.status(404).json({ error: true, message: "Label not found" });
+      throw new NotFoundError(`Label "${label}" does not exist for this note's owner.`);
     };
 
-    const note = await Note.findOne({ _id: noteId, userId: user._id });
-    if (!note) {
-      return res.status(404).json({ error: true, message: errors.noteNotFound });
-    };
+    await Note.updateOne(
+      { _id: noteId },
+      { $addToSet: { labels: labelDoc._id } }
+    );
 
-    if (!note.tags.some(id => id.equals(labelDoc._id))) {
-      note.tags.push(labelDoc._id);
-      await note.save();
-    };
-
-    const populatedNote = await getNoteByIdWithUser(note._id);
-    return res.json({ error: false, note: populatedNote, message: success.labelAdded });
+    const populatedNote = await getNoteByIdWithUser(noteId);
+    res.json({ success: true, note: populatedNote, message: success.labelAdded });
   } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
+    next(error);
   };
 };
 
-exports.removeLabel = async (req, res) => {
+exports.removeLabel = async (req, res, next) => {
   const noteId = req.params.noteId;
   const { label } = req.body;
   const user = req.user;
 
-  if (!label || label.trim() === "") {
-    return res.status(400).json({ error: true, message: errors.labelRequired });
-  };
-
   try {
+    const note = await Note.findOne({
+      _id: noteId,
+      $or: [{ userId: user._id }, { sharedWith: user.email }]
+    });
+
+    if (!note) {
+      throw new NotFoundError("Note not found or you don't have permission to edit it.");
+    };
+
     const labelDoc = await Label.findOne({ name: label, userId: user._id });
     if (!labelDoc) {
-      return res.status(404).json({ error: true, message: "Label not found" });
+      throw new NotFoundError("Label not found on this note.");
     };
 
-    const note = await Note.findOne({ _id: noteId, userId: user._id });
-    if (!note) {
-      return res.status(404).json({ error: true, message: errors.noteNotFound });
-    };
+    await Note.updateOne(
+      { _id: noteId },
+      { $pull: { labels: labelDoc._id } }
+    );
 
-    note.tags = note.tags.filter(id => !id.equals(labelDoc._id));
-    await note.save();
-
-    const populatedNote = await getNoteByIdWithUser(note._id);
-    return res.json({ error: false, note: populatedNote, message: success.labelRemoved });
+    const populatedNote = await getNoteByIdWithUser(noteId);
+    res.json({ success: true, note: populatedNote, message: success.labelRemoved });
   } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
+    next(error);
   };
 };
 
-exports.setReminder = async (req, res) => {
+exports.setReminder = async (req, res, next) => {
   const noteId = req.params.noteId;
   const { reminder } = req.body;
   const user = req.user;
 
   try {
-    const note = await findAndUpdateNote(noteId, user._id, { reminder });
-    return res.json({ error: false, note, message: success.reminderSet });
+    const updatedNote = await Note.findOneAndUpdate(
+      { _id: noteId, $or: [{ userId: user._id }, { sharedWith: user.email }] },
+      { reminder },
+      { new: true }
+    );
+
+    if (!updatedNote) {
+      throw new NotFoundError("Note not found or you don't have permission to edit it.");
+    };
+
+    const populatedNote = await getNoteByIdWithUser(updatedNote._id);
+    res.json({ success: true, note: populatedNote, message: success.reminderSet });
   } catch (error) {
-    return res.status(404).json({ error: true, message: error.message || errors.noteNotFound });
-  }
+    next(error);
+  };
 };
 
-exports.shareNote = async (req, res) => {
+exports.shareNote = async (req, res, next) => {
   const noteId = req.params.noteId;
   const { emails } = req.body;
-  const user = req.user;
-
-  if (!emails || !Array.isArray(emails) || emails.length === 0) {
-    return res.status(400).json({ error: true, message: errors.emailsRequired });
-  }
+  const sender = req.user;
 
   try {
-    const note = await Note.findOne({ _id: noteId, userId: user._id });
+    const note = await Note.findOne({ _id: noteId, userId: sender._id });
     if (!note) {
-      return res.status(404).json({ error: true, message: errors.noteNotFound });
-    }
+      throw new NotFoundError("Note not found or you don't have permission to share it.");
+    };
 
-    const newEmails = emails.filter(email => !note.sharedWith.includes(email));
-    if (newEmails.length) {
-      note.sharedWith.push(...newEmails);
-      await note.save();
-    }
+    const recipients = await User.find({ email: { $in: emails } });
+    if (recipients.length !== emails.length) {
+      const foundEmails = recipients.map(r => r.email);
+      const notFoundEmails = emails.filter(e => !foundEmails.includes(e));
+      throw new NotFoundError(`User(s) not found: ${notFoundEmails.join(", ")}`);
+    };
 
-    const populatedNote = await getNoteByIdWithUser(note._id);
-    return res.json({ error: false, note: populatedNote, message: success.shared });
+    const result = await Note.updateOne(
+      { _id: noteId },
+      { $addToSet: { sharedWith: { $each: emails } } }
+    );
+
+    for (const recipient of recipients) {
+      const notificationData = {
+        userId: recipient._id,
+        senderId: sender._id,
+        noteId: note._id,
+        type: "note-shared",
+        message: `${sender.firstName} shared a note with you: "${note.title}"`
+      };
+      await createNotification(notificationData);
+      const userRoom = `user_${recipient._id}`;
+      req.io.to(userRoom).emit("new_notification", notificationData);
+    };
+
+    const populatedNote = await getNoteByIdWithUser(noteId);
+    res.json({ success: true, note: populatedNote, message: success.shared });
   } catch (error) {
-    return res.status(500).json({ error: true, message: errors.internal });
-  }
+    next(error);
+  };
 };

--- a/backend/models/label.model.js
+++ b/backend/models/label.model.js
@@ -3,9 +3,7 @@ const Schema = mongoose.Schema;
 
 const labelSchema = new Schema({
     name: { type: String, required: true },
-    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
-     createdOn: { type: Date, default: Date.now },
-    updatedOn: { type: Date, default: Date.now },
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true }
 }, { timestamps: true });
 
 labelSchema.index({ userId: 1, name: 1 }, { unique: true });

--- a/backend/models/note.model.js
+++ b/backend/models/note.model.js
@@ -2,17 +2,16 @@ const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
 const noteSchema = new Schema({
-    title: { type: String, required: true, trim: true },
+    title: { type: String, required: true },
     content: { type: String, required: true },
-    tags: [{ type: Schema.Types.ObjectId, ref: "Label" }],
+    labels: [{ type: Schema.Types.ObjectId, ref: "Label" }],
     isPinned: { type: Boolean, default: false },
+    color: { type: String, default: "#ffffff" },
     userId: { type: Schema.Types.ObjectId, ref: "User", required: true, index: true },
-    sharedWith: [{ type: String, lowercase: true, trim: true }],
+    sharedWith: [{ type: String }],
     isArchived: { type: Boolean, default: false },
     isCompleted: { type: Boolean, default: false },
     reminder: { type: Date, default: null },
-    createdOn: { type: Date, default: Date.now },
-    updatedOn: { type: Date, default: Date.now },
 }, { timestamps: true });
 
 noteSchema.index({ userId: 1, isArchived: 1 });

--- a/backend/models/user.model.js
+++ b/backend/models/user.model.js
@@ -4,8 +4,14 @@ const Schema = mongoose.Schema;
 const userSchema = new Schema({
     firstName: { type: String, required: true },
     lastName: { type: String, required: true },
-     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
-    password: { type: String, required: true }
+    email: {
+        type: String,
+        required: true,
+        unique: true,
+        index: true
+    },
+    password: { type: String, required: true },
+    refreshToken: { type: String }
 }, { timestamps: true });
 
 userSchema.index({ email: 1 }, { unique: true });

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -8,5 +8,7 @@ const router = express.Router();
 
 router.post("/create-account", registerLimiter, validateRegisterFields, authController.createAccount);
 router.post("/login", loginLimiter, validateLoginFields, authController.login);
+router.get("/refresh", authController.handleRefreshToken);
+router.post("/logout", authController.logout);
 
 module.exports = router;

--- a/frontend/src/pages/Home/AddEditNotes.jsx
+++ b/frontend/src/pages/Home/AddEditNotes.jsx
@@ -68,11 +68,7 @@ const AddEditNotes = ({ type, noteData, onClose }) => {
   useEffect(() => {
     if (noteData) {
       setValue("title", noteData.title || "");
-      const labelNames =
-        (noteData.tags || noteData.labels || [])
-          .map((l) => (typeof l === "string" ? l : l?.name))
-          .filter(Boolean);
-      setValue("labels", labelNames);
+      setValue("labels", noteData.labels?.map((label) => label.name) || []);
       setValue("color", noteData.color || "#ffffff");
       const newContent = noteData.content || EMPTY_CONTENT;
       setValue("content", newContent);
@@ -110,10 +106,6 @@ const AddEditNotes = ({ type, noteData, onClose }) => {
     }
   }, [socket, noteData, type, setValue, editor]);
 
-  const idToName = (ids) =>
-    ids
-      .map((id) => availableLabels.find((l) => l._id === id)?.name)
-      .filter(Boolean);
 
   const onSubmit = async (data) => {
     const isContentEmpty = editor.getText().trim().length === 0;
@@ -123,18 +115,11 @@ const AddEditNotes = ({ type, noteData, onClose }) => {
     }
 
     try {
-      const payload = {
-        title: data.title?.trim() || "",
-        content: data.content,
-        color: data.color,
-        tags: idToName(data.labels),
-      };
-
       if (type === "edit") {
-        await editNote(noteData._id, payload);
+        await editNote(noteData._id, data);
       } else {
-        await addNote(payload);
-      };
+        await addNote(data);
+      }
       onClose();
     } catch (err) {
       const message = err.response?.data?.error?.message || `Failed to ${type} note.`;


### PR DESCRIPTION
This PR reverts the following commits on main:

- e1ddda1 fix(frontend): correct pagination mapping and make pin toggle optimistic
- 17b6147 feat(notes): map label IDs to names before sending to backend
- da58b7d fix(api): repair lean() save bugs, tag ObjectId mapping, secure filtering

Reason:
- Restore previous behavior while we investigate regressions with pagination, label mapping, and API ObjectId handling.

Notes:
- Generated via `git revert --no-commit e1ddda1 17b6147 da58b7d` and then a single revert commit.
- If we later want these changes back, we can "revert this revert".